### PR TITLE
Optimize command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ $ plex2mix list
 2: Bad
 ```
 
-You can thereafter pick the ones you wish to download by providing their indices:
+You can thereafter pick the ones you wish to enable by providing their indices:
 
 ```bash
-plex2mix download 0 1
+plex2mix enable 0 1
 ```
 
-You can also choose to download all the playlists on your server:
+You can also choose to enable all the playlists on your server:
 
 ```bash
-plex2mix download --all
+plex2mix enable --all
 ```
 
 Now, if you want to exclude a playlist from the above command you can ignore it:
@@ -65,11 +65,14 @@ Now, if you want to exclude a playlist from the above command you can ignore it:
 plex2mix ignore 2
 ```
 
-At some point, if you modified your playlists on the server you might want to update them locally, this is done with a refresh.
+At some point, you can download playlists and track with:
 
 ```bash
-plex2mix refresh
+plex2mix download
+plex2mix refresh # is an alias to download
 ```
+
+*if you modified your playlists on the server you might want to update them locally, just relaunch this command.*
 
 If you want clear unmapped tracks in downloaded playlists, you can use clear flag
 
@@ -89,10 +92,10 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  download  Download playlists
+  enable    Enable playlists
   ignore    Ignore playlists
   list      List playlists
-  refresh   Refresh playlists
+  download|refresh   Download playlists (or refresh)
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Plexamp team is however very reactive in implementing features, the above mentio
 
 ## Installation
 
-You must clone the repository locally and execute:
+You must clone this repository locally and execute:
 
 ```bash
 python setup.py install --user
@@ -47,16 +47,16 @@ $ plex2mix list
 2: Bad
 ```
 
-You can thereafter pick the ones you wish to enable by providing their indices:
+You can thereafter pick the ones you wish to save by providing their indices:
 
 ```bash
-plex2mix enable 0 1
+plex2mix save 0 1
 ```
 
-You can also choose to enable all the playlists on your server:
+You can also choose to save every playlists on your server:
 
 ```bash
-plex2mix enable --all
+plex2mix save --all
 ```
 
 Now, if you want to exclude a playlist from the above command you can ignore it:
@@ -65,19 +65,18 @@ Now, if you want to exclude a playlist from the above command you can ignore it:
 plex2mix ignore 2
 ```
 
-At some point, you can download playlists and track with:
+After your selection (save/ignore), you can download playlists and track with:
 
 ```bash
 plex2mix download
-plex2mix refresh # is an alias to download
 ```
 
-*if you modified your playlists on the server you might want to update them locally, just relaunch this command.*
+If you modified your playlists on the server you might want to update them locally, just execute this command again.
 
-If you want clear unmapped tracks in downloaded playlists, you can use clear flag
+If you want to clear unreferenced tracks, you can use the `clear` flag
 
 ```bash
-plex2mix refresh --clear
+plex2mix download --clear
 ```
 
 For any assistance you can query the help section:
@@ -92,10 +91,11 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  enable    Enable playlists
+  config    Print config
+  download  Download and refresh playlists
   ignore    Ignore playlists
   list      List playlists
-  download|refresh   Download playlists (or refresh)
+  save      Save playlists to download
 ```
 
 ## Configuration

--- a/plex2mix/downloader.py
+++ b/plex2mix/downloader.py
@@ -15,7 +15,7 @@ class Downloader:
         self.path = os.path.expanduser(os.path.join(path))
         self.playlists_path = os.path.expanduser(os.path.join(playlists_path))
         self.pool = ThreadPoolExecutor(max_workers=threads)
-        self.downloadedTracks = []
+        self.downloaded = []
 
     def get_playlists(self) -> list:
         if self.playlists is None:
@@ -37,7 +37,7 @@ class Downloader:
         else:
             track.download(album_path, keep_original_name=True)
 
-        self.downloadedTracks.append(filepath)
+        self.downloaded.append(filepath)
 
         return filepath
 

--- a/plex2mix/main.py
+++ b/plex2mix/main.py
@@ -4,13 +4,12 @@ import os
 import click
 import yaml
 import time
-from click_aliases import ClickAliasedGroup
 from plexapi.myplex import MyPlexPinLogin, MyPlexAccount
 from plexapi.server import PlexServer
 from plex2mix.downloader import Downloader
 
 
-@ click.group(cls=ClickAliasedGroup)
+@ click.group()
 @ click.pass_context
 def cli(ctx) -> None:
     """plex2mix"""
@@ -158,7 +157,8 @@ def enable(ctx, indices=[], enable_all=False) -> None:
         ctx.obj["config"]["playlists"]["ignored"] = ignored
         ctx.obj["save"]()
 
-@ cli.command(aliases=['refresh'])
+
+@ cli.command()
 @click.option('-f', '--force', is_flag=True, help='Force refresh')
 @ click.option('-c', '--clear', is_flag=True, help='Clear unmapped tracks')
 @ click.pass_context
@@ -184,6 +184,7 @@ def download(ctx, force=False) -> None:
                 if pathFile not in downloadedTracks:
                     os.remove(pathFile)
     remove_empty_folders(configPath)
+
 
 @ cli.command()
 @ click.argument('indices',  nargs=-1, type=int)
@@ -217,6 +218,7 @@ def config(ctx):
     """Show config"""
     click.echo(f"Configuration file is located at {ctx.obj['config_file']}")
     click.echo(ctx.obj["config"])
+
 
 def remove_empty_folders(path_abs):
     for path, _, _ in os.walk(path_abs, topdown=False):

--- a/plex2mix/main.py
+++ b/plex2mix/main.py
@@ -129,7 +129,7 @@ def list(ctx) -> None:
 
 @ cli.command()
 @ click.argument('indices',  nargs=-1, type=int)
-@ click.option('-a', '--all', 'save_all', is_flag=True, help='Enable all playlists')
+@ click.option('-a', '--all', 'save_all', is_flag=True, help='Save all playlists')
 @ click.pass_context
 def save(ctx, indices=[], save_all=False) -> None:
     """Save playlists to download"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3
 idna==3.4
+click-aliases==1.0.1
 # Editable install with no version control (plex2mix==0.0.0)
 -e /home/francois-xavierwicht/Programmation/plex2mix-cli
 PlexAPI==4.13.4

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'Click',
+        'click-aliases',
         'PlexAPI',
         'PyYAML',
     ],


### PR DESCRIPTION
Optimize command logic :

- `plex2mix enable X` : enable playlist X
- `plex2mix ignore X` : ignore (disable) playlist X
- `plex2mix download` : download enabled playlists and related tracks
- `plex2mix refresh` : is alias to download to keep retro compatibility

Merge PR before : https://github.com/anatosun/plex2mix/pull/5